### PR TITLE
fix osx compile step

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -69,4 +69,5 @@ LDFLAGS += -L ../deps/librdkafka/src \
            -lz \
            -lssl \
            -lcrypto \
-           -lstdc++
+           -lstdc++ \
+           -llz4


### PR DESCRIPTION
hi,

when adding it to an elixir project on OSX i hit the compilation error. I needed to add additional flag for the linker in order to compile `erlkaf` 

btw. Would you consider this lib production ready ? (librdkafka is so i assume you lib i good to use right ?) 