### PR TITLE
decode json to maps instead of proplists

### DIFF
--- a/src/erlkaf.erl
+++ b/src/erlkaf.erl
@@ -73,7 +73,7 @@ stop_client(ClientId) ->
     erlkaf_manager:stop_client(ClientId).
 
 -spec get_stats(client_id()) ->
-    {ok, list()} | {error, reason()}.
+    {ok, map()} | {error, reason()}.
 
 get_stats(ClientId) ->
     case erlkaf_cache_client:get(ClientId) of

--- a/src/erlkaf_consumer_callbacks.erl
+++ b/src/erlkaf_consumer_callbacks.erl
@@ -8,7 +8,7 @@
 -callback handle_message(#erlkaf_msg{}, state()) ->
     {ok, state()} | {error, reason(), state()}.
 
--callback stats_callback(client_id(), list()) ->
+-callback stats_callback(client_id(), map()) ->
     ok.
 
 -optional_callbacks([

--- a/src/erlkaf_json.erl
+++ b/src/erlkaf_json.erl
@@ -10,7 +10,7 @@ encode(Val) ->
     jsone:encode(Val, [{float_format, [{decimals, 4}, compact]}]).
 
 decode(Val) ->
-    jsone:decode(Val, [{object_format, proplist}]).
+    jsone:decode(Val, [{object_format, map}]).
 
 try_decode(Val) ->
-    jsone:try_decode(Val, [{object_format, proplist}]).
+    jsone:try_decode(Val, [{object_format, map}]).

--- a/src/erlkaf_producer_callbacks.erl
+++ b/src/erlkaf_producer_callbacks.erl
@@ -5,7 +5,7 @@
 -callback delivery_report(DeliveryStatus:: ok | {error, any()}, Message::#erlkaf_msg{}) ->
     ok.
 
--callback stats_callback(ClientId::client_id(), Stats::list()) ->
+-callback stats_callback(ClientId::client_id(), Stats::map()) ->
     ok.
 
 -optional_callbacks([stats_callback/2, delivery_report/2]).


### PR DESCRIPTION
Me again :). I'm working on a library for publishing the statistics produced and I wanted to ask why proplists instead of maps? Maps would be nice for matching out particular stats to publish rather than having to do a `proplists:get_value` for each one. I figured I'd open a PR to use maps to do so just in case it was simply an artifact of history and you were interested in the change.