### PR TITLE
added plugin_library_paths client configuration

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -79,6 +79,7 @@ compression_codec                        |  P  | none, gzip, snappy, lz4, zstd |
 batch_num_messages                       |  P  | 1 .. 1000000    |         10000 | Maximum number of messages batched in one MessageSet. The total MessageSet size is also limited by `message_max_bytes`
 delivery_report_only_error               |  P  | true, false     |         false | Only provide delivery reports for failed messages
 delivery_report_callback                 |  P  | module or fun/2 |       undefined| A callback where delivery reports are sent (`erlkaf_producer_callbacks` behaviour) 
+plugin_library_paths                     |  *  |                 |       undefined| Path where `librdkafka` plugins are located
 
 ## Topic configuration properties
 

--- a/include/erlkaf.hrl
+++ b/include/erlkaf.hrl
@@ -103,7 +103,8 @@
     {retry_backoff_ms, integer()} |
     {compression_codec, compression_codec()} |
     {batch_num_messages, integer()} |
-    {delivery_report_only_error, boolean()}.
+    {delivery_report_only_error, boolean()} |
+    {plugin_library_paths, binary()}.
 
 % records
 

--- a/src/erlkaf_config.erl
+++ b/src/erlkaf_config.erl
@@ -245,6 +245,8 @@ to_librdkafka_config(batch_num_messages, V) ->
     {<<"batch.num.messages">>, erlkaf_utils:to_binary(V)};
 to_librdkafka_config(delivery_report_only_error, V) ->
     {<<"delivery.report.only.error">>, erlkaf_utils:to_binary(V)};
+to_librdkafka_config(plugin_library_paths, V) ->
+    {<<"plugin.library.paths">>, erlkaf_utils:to_binary(V)};
 to_librdkafka_config(K, V) ->
     throw({error, {options, {K, V}}}).
 


### PR DESCRIPTION
This PR makes it possible to load `librdkafka` plugins from `erlkaf`.
I have a need at work to load the confluent monitoring plugin, which is only possible if the client is able to load them.