### PR TITLE
Debian compilation fix

### DIFF
--- a/c_src/erlkaf_consumer.cc
+++ b/c_src/erlkaf_consumer.cc
@@ -456,7 +456,7 @@ ERL_NIF_TERM enif_consumer_cleanup(ErlNifEnv* env, int argc, const ERL_NIF_TERM 
     if(!enif_get_resource(env, argv[0], data->res_consumer, reinterpret_cast<void**>(&consumer)))
         return make_badarg(env);
 
-	consumer->running = false;
+    consumer->running = false;
     data->notifier_->remove(consumer->kf);
     consumer->closed_future = new std::future<bool>(std::async(std::launch::async, cleanup_consumer, consumer, true));
 


### PR DESCRIPTION
/home/admin/data/new_ejjabered/deps/erlkaf/c_src/erlkaf_consumer.cc:456:5: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
     if(!enif_get_resource(env, argv[0], data->res_consumer, reinterpret_cast<void**>(&consumer)))
     ^~
/home/admin/data/new_ejjabered/deps/erlkaf/c_src/erlkaf_consumer.cc:459:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
  consumer->running = false;
  ^~~~~~~~
cc1plus: all warnings being treated as errors