### PR TITLE
Explicitly include <string>

### DIFF
--- a/c_src/queuecallbacksdispatcher.cc
+++ b/c_src/queuecallbacksdispatcher.cc
@@ -3,6 +3,7 @@
 
 #include <chrono>
 #include <limits>
+#include <string>
 
 namespace  {
 


### PR DESCRIPTION
in queuecallbacksdispatcher.cc

This makes the project build correctly in latest manjaro-stable.

Fixes #31 