### PR TITLE
Get metadata from Kafka broker with dirty IO bound nif - redux

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -52,6 +52,8 @@ ifeq ($(UNAME_SYS), darwin)
 				-Wl,-U,_enif_make_resource \
 				-Wl,-U,_enif_make_string_len \
 				-Wl,-U,_enif_make_tuple \
+				-Wl,-U,_enif_make_new_map \
+				-Wl,-U,_enif_make_map_put \
 				-Wl,-U,_enif_make_list \
 				-Wl,-U,_enif_make_list_from_array \
 				-Wl,-U,_enif_make_ulong \

--- a/c_src/erlkaf_nif.cc
+++ b/c_src/erlkaf_nif.cc
@@ -13,6 +13,16 @@ const char kAtomTrue[] = "true";
 const char kAtomFalse[] = "false";
 const char kAtomBadArg[] = "badarg";
 const char kAtomOptions[] = "options";
+const char kAtomBrokers[] = "brokers";
+const char kAtomTopics[] = "topics";
+const char kAtomPartitions[] = "partitions";
+const char kAtomId[] = "id";
+const char kAtomHost[] = "host";
+const char kAtomPort[] = "port";
+const char kAtomName[] = "name";
+const char kAtomLeader[] = "leader";
+const char kAtomReplicas[] = "replicas";
+const char kAtomIsrs[] = "isrs";
 const char kAtomMessage[] = "erlkaf_msg";
 const char kAtomDeliveryReport[] = "delivery_report";
 const char kAtomLogEvent[] = "log_message";
@@ -42,6 +52,16 @@ int on_nif_load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
     ATOMS.atomFalse = make_atom(env, kAtomFalse);
     ATOMS.atomOptions = make_atom(env, kAtomOptions);
     ATOMS.atomBadArg = make_atom(env, kAtomBadArg);
+    ATOMS.atomBrokers = make_atom(env, kAtomBrokers);
+    ATOMS.atomTopics = make_atom(env, kAtomTopics);
+    ATOMS.atomPartitions = make_atom(env, kAtomPartitions);
+    ATOMS.atomId = make_atom(env, kAtomId);
+    ATOMS.atomHost = make_atom(env, kAtomHost);
+    ATOMS.atomPort = make_atom(env, kAtomPort);
+    ATOMS.atomName = make_atom(env, kAtomName);
+    ATOMS.atomLeader = make_atom(env, kAtomLeader);
+    ATOMS.atomReplicas = make_atom(env, kAtomReplicas);
+    ATOMS.atomIsrs = make_atom(env, kAtomIsrs);
     ATOMS.atomMessage = make_atom(env, kAtomMessage);
     ATOMS.atomDeliveryReport = make_atom(env, kAtomDeliveryReport);
     ATOMS.atomLogEvent = make_atom(env, kAtomLogEvent);
@@ -95,6 +115,7 @@ static ErlNifFunc nif_funcs[] =
     {"producer_topic_new", 3, enif_producer_topic_new},
     {"producer_cleanup", 1, enif_producer_cleanup},
     {"produce", 6, enif_produce},
+    {"get_metadata", 1, enif_get_metadata, ERL_NIF_DIRTY_JOB_IO_BOUND},
 
     {"consumer_new", 4, enif_consumer_new},
     {"consumer_partition_revoke_completed", 1, enif_consumer_partition_revoke_completed},

--- a/c_src/erlkaf_nif.h
+++ b/c_src/erlkaf_nif.h
@@ -15,6 +15,16 @@ struct atoms
     ERL_NIF_TERM atomBadArg;
     ERL_NIF_TERM atomOptions;
     ERL_NIF_TERM atomMessage;
+    ERL_NIF_TERM atomBrokers;
+    ERL_NIF_TERM atomTopics;
+    ERL_NIF_TERM atomPartitions;
+    ERL_NIF_TERM atomId;
+    ERL_NIF_TERM atomHost;
+    ERL_NIF_TERM atomPort;
+    ERL_NIF_TERM atomName;
+    ERL_NIF_TERM atomLeader;
+    ERL_NIF_TERM atomReplicas;
+    ERL_NIF_TERM atomIsrs;
     ERL_NIF_TERM atomDeliveryReport;
     ERL_NIF_TERM atomLogEvent;
     ERL_NIF_TERM atomAssignPartition;

--- a/c_src/erlkaf_producer.cc
+++ b/c_src/erlkaf_producer.cc
@@ -243,6 +243,102 @@ ERL_NIF_TERM enif_producer_cleanup(ErlNifEnv* env, int argc, const ERL_NIF_TERM 
     return ATOMS.atomOk;
 }
 
+ERL_NIF_TERM enif_get_metadata(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    UNUSED(argc);
+
+    erlkaf_data* data = static_cast<erlkaf_data*>(enif_priv_data(env));
+
+    enif_producer* producer;
+
+    if(!enif_get_resource(env, argv[0], data->res_producer,  reinterpret_cast<void**>(&producer)))
+        return make_badarg(env);
+
+    const struct rd_kafka_metadata *metadata;
+    rd_kafka_resp_err_t err;
+
+    /* Fetch metadata */
+    err = rd_kafka_metadata(producer->kf, 1, NULL, &metadata, 5000);
+    if (err != RD_KAFKA_RESP_ERR_NO_ERROR) {
+        return make_error(env, "failed to get metadata");
+    }
+
+    ERL_NIF_TERM metadata_map = enif_make_new_map(env);
+    ERL_NIF_TERM broker_arr[metadata->broker_cnt];
+
+    for (int i = 0 ; i < metadata->broker_cnt ; i++) {
+        ERL_NIF_TERM broker_map = enif_make_new_map(env);
+        ERL_NIF_TERM id_term = enif_make_int(env, metadata->brokers[i].id);
+        ERL_NIF_TERM host_term = make_binary(env, metadata->brokers[i].host, strlen(metadata->brokers[i].host));
+        ERL_NIF_TERM port_term = enif_make_int64(env, metadata->brokers[i].port);
+        enif_make_map_put(env, broker_map, ATOMS.atomId, id_term, &broker_map);
+        enif_make_map_put(env, broker_map, ATOMS.atomHost, host_term, &broker_map);
+        enif_make_map_put(env, broker_map, ATOMS.atomPort, port_term, &broker_map);
+        broker_arr[i] = broker_map;
+    }
+
+    ERL_NIF_TERM broker_list = enif_make_list_from_array(env, broker_arr, metadata->broker_cnt);
+    enif_make_map_put(env, metadata_map, ATOMS.atomBrokers, broker_list, &metadata_map);
+
+    ERL_NIF_TERM topic_arr[metadata->topic_cnt];
+
+    for (int i = 0 ; i < metadata->topic_cnt ; i++) {
+        const struct rd_kafka_metadata_topic *t = &metadata->topics[i];
+        if (t->err) {
+            if (t->err == RD_KAFKA_RESP_ERR_LEADER_NOT_AVAILABLE)
+                return make_error(env, "failed to get topic info");
+        }
+        ERL_NIF_TERM topic_map = enif_make_new_map(env);
+        ERL_NIF_TERM topic_name_term = make_binary(env, t->topic, strlen(t->topic));
+        enif_make_map_put(env, topic_map, ATOMS.atomName, topic_name_term, &topic_map);
+
+        ERL_NIF_TERM partition_arr[t->partition_cnt];
+
+        for (int j = 0 ; j < t->partition_cnt ; j++) {
+            const struct rd_kafka_metadata_partition *p;
+            p = &t->partitions[j];
+
+            if (p->err)
+                return make_error(env, "failed to get partition info");
+
+            ERL_NIF_TERM partition_map = enif_make_new_map(env);
+            ERL_NIF_TERM id_term = enif_make_int(env, p->id);
+            ERL_NIF_TERM leader_term = enif_make_int(env, p->leader);
+
+            ERL_NIF_TERM replica_arr[p->replica_cnt];
+            for (int k = 0 ; k < p->replica_cnt ; k++) {
+                ERL_NIF_TERM replica_term = enif_make_int(env, p->replicas[k]);
+                replica_arr[k] = replica_term;
+            }
+
+            ERL_NIF_TERM replica_list = enif_make_list_from_array(env, replica_arr, p->replica_cnt);
+
+            ERL_NIF_TERM isr_arr[p->isr_cnt];
+            for (int k = 0 ; k < p->isr_cnt ; k++) {
+                ERL_NIF_TERM isr_term = enif_make_int(env, p->isrs[k]);
+                isr_arr[k] = isr_term;
+            }
+
+            ERL_NIF_TERM isr_list = enif_make_list_from_array(env, isr_arr, p->isr_cnt);
+            enif_make_map_put(env, partition_map, ATOMS.atomId, id_term, &partition_map);
+            enif_make_map_put(env, partition_map, ATOMS.atomLeader, leader_term, &partition_map);
+            enif_make_map_put(env, partition_map, ATOMS.atomReplicas, replica_list, &partition_map);
+            enif_make_map_put(env, partition_map, ATOMS.atomIsrs, isr_list, &partition_map);
+            partition_arr[j] = partition_map;
+        }
+        ERL_NIF_TERM partition_list = enif_make_list_from_array(env, partition_arr, t->partition_cnt);
+        enif_make_map_put(env, topic_map, ATOMS.atomPartitions, partition_list, &topic_map);
+        topic_arr[i] = topic_map;
+    }
+
+    ERL_NIF_TERM topic_list = enif_make_list_from_array(env, topic_arr, metadata->topic_cnt);
+    enif_make_map_put(env, metadata_map, ATOMS.atomTopics, topic_list, &metadata_map);
+
+    rd_kafka_metadata_destroy(metadata);
+
+    return enif_make_tuple2(env, ATOMS.atomOk, metadata_map);
+}
+
 ERL_NIF_TERM enif_produce(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     UNUSED(argc);

--- a/c_src/erlkaf_producer.h
+++ b/c_src/erlkaf_producer.h
@@ -10,5 +10,6 @@ ERL_NIF_TERM enif_producer_topic_new(ErlNifEnv* env, int argc, const ERL_NIF_TER
 ERL_NIF_TERM enif_producer_set_owner(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM enif_producer_cleanup(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM enif_produce(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM enif_get_metadata(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 
 #endif  // C_SRC_ERLKAF_PRODUCER_H_

--- a/src/erlkaf.erl
+++ b/src/erlkaf.erl
@@ -18,7 +18,9 @@
 
     produce/4,
     produce/5,
-    produce/6
+    produce/6,
+
+    get_metadata/1
 ]).
 
 -spec start() ->
@@ -103,6 +105,23 @@ create_topic(ClientId, TopicName, TopicConfig) ->
             end;
         _ ->
             {error, ?ERR_UNDEFINED_CLIENT}
+    end.
+
+-spec get_metadata(client_id()) ->
+    {ok, map()} | {error, reason()}.
+get_metadata(ClientId) ->
+    case erlkaf_cache_client:get(ClientId) of
+        {ok, ClientRef, _ClientPid} ->
+            case erlkaf_nif:get_metadata(ClientRef) of
+                {ok, res} ->
+                    res;
+                Error ->
+                    Error
+            end;
+        undefined ->
+            {error, ?ERR_UNDEFINED_CLIENT};
+        Error ->
+            Error
     end.
 
 -spec produce(client_id(), binary(), key(), binary()) ->

--- a/src/erlkaf.erl
+++ b/src/erlkaf.erl
@@ -112,12 +112,7 @@ create_topic(ClientId, TopicName, TopicConfig) ->
 get_metadata(ClientId) ->
     case erlkaf_cache_client:get(ClientId) of
         {ok, ClientRef, _ClientPid} ->
-            case erlkaf_nif:get_metadata(ClientRef) of
-                {ok, res} ->
-                    res;
-                Error ->
-                    Error
-            end;
+            erlkaf_nif:get_metadata(ClientRef);
         undefined ->
             {error, ?ERR_UNDEFINED_CLIENT};
         Error ->

--- a/src/erlkaf_nif.erl
+++ b/src/erlkaf_nif.erl
@@ -13,6 +13,7 @@
     producer_set_owner/2,
     producer_topic_new/3,
     produce/6,
+    get_metadata/1,
 
     consumer_new/4,
     consumer_partition_revoke_completed/1,
@@ -48,6 +49,9 @@ producer_topic_new(_ClientRef, _TopicName, _TopicConfig) ->
     ?NOT_LOADED.
 
 produce(_ClientRef, _TopicRef, _Partition, _Key, _Value, _Headers) ->
+    ?NOT_LOADED.
+
+get_metadata(_ClientRef) ->
     ?NOT_LOADED.
 
 consumer_new(_GroupId, _Topics, _ClientConfig, _TopicsConfig) ->


### PR DESCRIPTION
Redux of https://github.com/silviucpp/erlkaf/pull/19 with mentioned change

```erlang
erlkaf:start(),
erlkaf:create_producer(client_producer, [{bootstrap_servers, "localhost:9092"}]),
erlkaf:get_metadata(client_producer).
```