### PR TITLE
Fix create_consumer_group spec

### DIFF
--- a/include/erlkaf.hrl
+++ b/include/erlkaf.hrl
@@ -18,6 +18,12 @@
 -type overflow_strategy() :: local_disk_queue | block_calling_process | drop_records.
 -type partitioner() :: random|consistent|consistent_random|murmur2|murmur2_random.
 -type headers() :: undefined | proplists:proplist() | maps:map().
+-type callback_module() :: {callback_module, atom()}.
+-type callback_args() :: {callback_args, [any()]}.
+-type dispatch_mode() :: one_by_one | {batch, non_neg_integer()}.
+-type callback_dispatch_mode() :: {dispatch_mode, dispatch_mode()}.
+-type callback_options() :: callback_module() | callback_args() | callback_dispatch_mode().
+-type topic() :: {binary(), [callback_options()]}.
 
 -type topic_option() ::
     {request_required_acks, integer()} |

--- a/src/erlkaf.erl
+++ b/src/erlkaf.erl
@@ -60,7 +60,7 @@ create_producer(ClientId, ClientConfig) ->
             Error
     end.
 
--spec create_consumer_group(client_id(), binary(), [binary()], [client_option()], [topic_option()]) ->
+-spec create_consumer_group(client_id(), binary(), [topic()], [client_option()], [topic_option()]) ->
     ok | {error, reason()}.
 
 create_consumer_group(ClientId, GroupId, Topics, ClientConfig0, DefaultTopicsConfig) ->


### PR DESCRIPTION
Previously the code check 'topic' type and the spec 'topic'
type for create_consumer_group function did not match. Add the
needed type definitions to include/erlkaf.hrl and used them into
src/erlkaf.erl for that function spec.