### PR TITLE
Consumer queue cleanup

### DIFF
--- a/src/erlkaf_consumer.erl
+++ b/src/erlkaf_consumer.erl
@@ -215,9 +215,8 @@ process_events_one_by_one([], _ClientRef, _Backoff, _CbModule, CbState) ->
 recv_stop() ->
     receive {stop, _From, _Tag} = Msg -> Msg after 0 -> false end.
 
-handle_stop(From, Tag, #state{topic_name = TopicName, partition = Partition, queue_ref = Queue}) ->
+handle_stop(From, Tag, #state{topic_name = TopicName, partition = Partition}) ->
     ?LOG_INFO("stop consumer for: ~p partition: ~p", [TopicName, Partition]),
-    ok = erlkaf_nif:consumer_queue_cleanup(Queue),
     From ! {stopped, Tag}.
 
 exponential_backoff(0) ->


### PR DESCRIPTION
I moved `consumer_queue_cleanup` calls to the consumer_group level so that the function can always be called when partitions are revoked. 

This may have fixed issue #47