### PR TITLE
fix: avoid assigning partitions if consumer is not running

### DIFF
--- a/c_src/erlkaf_consumer.cc
+++ b/c_src/erlkaf_consumer.cc
@@ -103,6 +103,12 @@ ERL_NIF_TERM partition_list_to_nif(ErlNifEnv* env, enif_consumer* consumer, rd_k
 
 void assign_partitions(ErlNifEnv* env, enif_consumer* consumer, rd_kafka_t *rk, rd_kafka_topic_partition_list_t *partitions)
 {
+    if(!consumer->running)
+    {
+        rd_kafka_assign(rk, NULL);
+        return;
+    }
+    
     rd_kafka_resp_err_t response = rd_kafka_assign(rk, partitions);
 
     if(response != RD_KAFKA_RESP_ERR_NO_ERROR)


### PR DESCRIPTION
Hi!

We are having some problems when trying to stop multiple clients of the same consumer group concurrently. We have seen that in some occasions, we are receiving partition assignment requests (I guess due to rebalancing when stopping another client) on clients that already have the running flag set to false. This is preventing the client from being completely stopped (and I think generating a deadlock by not releasing all the rd_kafka objects).

I have included a check in the assignment method to verify that the client is not running (same mechanism as in the revoke partitions function).