### PR TITLE
Added zlib1g-dev lib into README.md for fresh Ubuntu install

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -36,7 +36,7 @@ into the topics list. This breaks the backward compatibility for the API and con
 On Ubuntu make sure you have installed :
 
 ```sh
-sudo apt-get install libsasl2-dev liblz4-dev libzstd-dev
+sudo apt-get install libsasl2-dev liblz4-dev libzstd-dev zlib1g-dev
 ```
 
 Add `erlkaf` as a dependency to your project. The library works with `rebar`, `rebar3` or `hex.pm`


### PR DESCRIPTION
During the installation of projects using erlkaf on a fresh Ubuntu system, I encountered errors due to the absence of the zlib1g-dev package.

As related in this image:
![image](https://github.com/silviucpp/erlkaf/assets/10719452/b9a323d8-68ca-4ac4-94d6-0ccb3888e148)
