### PR TITLE
Add erlang 26.2.2 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
       dist: jammy
       otp_release: 25.2.1
 
+    - os: linux
+      dist: jammy
+      otp_release: 26.2.2
+
     - os: osx
       osx_image: xcode12.4
       language: generic


### PR DESCRIPTION
We are running into issues with Erlang 26.2.2. I'm curious if this will work in your travis build. If so it may help us ping down what is wrong in our configuration. 