### PR TITLE
Removing io:format in on_load for erlang 26, temporary

### DIFF
--- a/src/erlkaf_nif.erl
+++ b/src/erlkaf_nif.erl
@@ -27,7 +27,6 @@
 
 load_nif() ->
     SoName = erlkaf_utils:get_priv_path(?MODULE),
-    io:format(<<"Loading library: ~p ~n">>, [SoName]),
     ok = erlang:load_nif(SoName, 0).
 
 not_loaded(Line) ->


### PR DESCRIPTION
Until erlang gets a fix for this io:format + on_load issue (in erlang 26.1.2 and 26.2.2, at least), this fixes any startup problems.

Resolves #70 