### PR TITLE
Poll consumer

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -238,6 +238,69 @@ You can call those like:
 ok = test_consumer:create_consumer().
 ```
 
+#### Polling consumer
+
+There is another type of consumer where users explicitly request more messages from Kafka on demand.
+To use this consumer, you need to set the `poll_consumer` property to `true` in the client configuration.
+Then, when defining the topics to connect to, you can set a `poll_batch_size` which will be the number
+of events to request per topic partition.
+
+After that, you only need to call repeatedly the function `erlkaf:poll(ClientId, Timeout)`
+or simply `erlkaf:poll(ClientId)` (to use a default timeout of 5000 ms) to ask for more
+events to Kafka.
+
+Likewise, you need to commit offsets per topic/partition using the function
+`erlkaf:commit_offsets(ClientId, PartitionOffsets)`. `PartitionOffsets` is a list
+of tuples in the form of `{Topic, Partition, Offset}`.
+
+This is an example of a module that uses the explicit polling consumer mechanism:
+
+```erlang
+-module(test_poll_consumer).
+
+-define(TOPICS, [
+    {<<"benchmark">>, [
+       {poll_batch_size, 50} % default value is 100
+   ]}
+]).
+
+-export([
+    create_consumer/0,
+    process/0
+]).
+
+create_consumer() ->
+    erlkaf:start(),
+    ClientId = client_consumer,
+    GroupId = <<"erlkaf_consumer">>,
+    ClientCfg = [{bootstrap_servers, <<"broker1:9092">>}, {poll_consumer, true}],
+    TopicConf = [{auto_offset_reset, smallest}],
+    ok = erlkaf:create_consumer_group(ClientId, GroupId, ?TOPICS, ClientCfg, TopicConf).
+
+process() ->
+    {ok, Received} = erlkaf:poll(client_consumer, 5000),
+    lists:foreach(fun({Topic, Partition, Events, _LastOffset}) ->
+        io:format("Received ~p events from topic ~p and partition ~p \n", [Events, Topic, Partition])
+    end, Received),
+
+    PartitionOffsets = lists:map(fun({Topic, Partition, _Events, LastOffset}) ->
+        {Topic, Partition, LastOffset}
+    end, Received),
+    erlkaf:commit_offsets(client_consumer, PartitionOffsets).
+```
+
+Then you can create the consumer:
+
+```erlang
+ok = test_poll_consumer:create_consumer().
+```
+
+And once the partitions have been assigned, you can poll events from Kafka:
+
+```erlang
+test_poll_consumer:process().
+```
+
 ### Error messages
 
 We forward all rdkafka errors to the calling application. To translate the received error, please use `get_readable_error/1` on the returned error to get a translated message

--- a/include/erlkaf.hrl
+++ b/include/erlkaf.hrl
@@ -24,7 +24,7 @@
 -type dispatch_mode() :: one_by_one | {batch, non_neg_integer()}.
 -type callback_dispatch_mode() :: {dispatch_mode, dispatch_mode()}.
 -type callback_options() :: callback_module() | callback_args() | callback_dispatch_mode().
--type topic() :: {binary(), [callback_options()]}.
+-type topic() :: {binary(), [callback_options()]} | {binary(), proplists:proplist()}.
 -type timestamp_type() :: not_available | create_time | log_append_time.
 
 -type topic_option() ::
@@ -142,7 +142,8 @@
     {batch_size, non_neg_integer()} |
     {delivery_report_only_error, boolean()} |
     {delivery_report_callback, any()} |
-    {sticky_partitioning_linger_ms, non_neg_integer()}.
+    {sticky_partitioning_linger_ms, non_neg_integer()} |
+    {oauthbearer_token_refresh_callback, any()}.
 
 % records
 

--- a/src/erlkaf_config.erl
+++ b/src/erlkaf_config.erl
@@ -99,6 +99,8 @@ is_erlkaf_config(queue_buffering_overflow_strategy = K, V) ->
         _ ->
             throw({error, {options, {K, V}}})
     end;
+is_erlkaf_config(poll_consumer = _K, V) ->
+    is_boolean(V);
 is_erlkaf_config(_, _) ->
     false.
 

--- a/src/erlkaf_poll_consumer.erl
+++ b/src/erlkaf_poll_consumer.erl
@@ -1,0 +1,95 @@
+-module(erlkaf_poll_consumer).
+
+-include("erlkaf_private.hrl").
+
+-define(DEFAULT_BATCH_SIZE, 100).
+
+-behaviour(gen_server).
+
+-export([
+    start_link/6,
+    stop/1,
+
+    % gen_server
+
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+-record(state, {
+    client_ref,
+    topic_name,
+    partition,
+    queue_ref,
+    poll_batch_size
+}).
+
+start_link(ClientRef, TopicName, Partition, Offset, QueueRef, TopicSettings) ->
+    gen_server:start_link(
+        ?MODULE, [ClientRef, TopicName, Partition, Offset, QueueRef, TopicSettings], []
+    ).
+
+stop(Pid) ->
+    case erlang:is_process_alive(Pid) of
+        true ->
+            Tag = make_ref(),
+            Pid ! {stop, self(), Tag},
+
+            receive
+                {stopped, Tag} ->
+                    ok
+            after 5000 ->
+                exit(Pid, kill)
+            end;
+        _ ->
+            {error, not_alive}
+    end.
+
+init([ClientRef, TopicName, Partition, Offset, QueueRef, TopicSettings]) ->
+    ?LOG_DEBUG("start poll consumer for: ~p partition: ~p offset: ~p", [
+        TopicName, Partition, Offset
+    ]),
+
+    PollBatchSize = erlkaf_utils:lookup(poll_batch_size, TopicSettings, ?DEFAULT_BATCH_SIZE),
+
+    {ok, #state{
+        client_ref = ClientRef,
+        topic_name = TopicName,
+        partition = Partition,
+        queue_ref = QueueRef,
+        poll_batch_size = PollBatchSize
+    }}.
+
+handle_call(poll, _From, #state{queue_ref = Queue, poll_batch_size = PollBatchSize} = State) ->
+    case erlkaf_nif:consumer_queue_poll(Queue, PollBatchSize) of
+        {ok, Events, LastOffset} ->
+            {reply, {ok, Events, LastOffset}, State};
+        Error ->
+            ?LOG_INFO("~p poll events error: ~p", [?MODULE, Error]),
+            throw({error, Error})
+    end;
+
+handle_call(Request, _From, State) ->
+    ?LOG_ERROR("handle_call unexpected message: ~p", [Request]),
+    {reply, ok, State}.
+
+handle_cast({commit_offset, Offset}, #state{
+        client_ref = ClientRef,
+        topic_name = Topic,
+        partition = Partition} = State) ->
+    erlkaf_nif:consumer_offset_store(ClientRef, Topic, Partition, Offset),
+    {noreply, State};
+
+handle_cast(Request, State) ->
+    ?LOG_ERROR("handle_cast unexpected message: ~p", [Request]),
+    {noreply, State}.
+
+handle_info({stop, From, Tag}, State) ->
+    handle_stop(From, Tag, State),
+    {stop, normal, State}.
+
+handle_stop(From, Tag, #state{topic_name = TopicName, partition = Partition}) ->
+    ?LOG_INFO("stop poll consumer for: ~p partition: ~p", [TopicName, Partition]),
+    From ! {stopped, Tag}.


### PR DESCRIPTION
Hi Silviu,

This is the PR according to the [issue](https://github.com/silviucpp/erlkaf/issues/78) I opened about the explicit poll consumer. 

Instead of creating a `consumer_behaviour` to implement by anyone who wants to implement their own consumer, I have created a `consumer_group_behaviour` module to do that at consumer group level. The main reason is that I needed to create a `poll` function inside the consumer_group module and perhaps it is preferable to keep it separated from the current functionality. Anyway, I can change it if necessary

