### PR TITLE
Fix deprecated type usage in type definition

### DIFF
--- a/include/erlkaf.hrl
+++ b/include/erlkaf.hrl
@@ -18,7 +18,7 @@
 -type security_protocol() :: plaintext | ssl | sasl_plaintext | sasl_ssl.
 -type overflow_strategy() :: local_disk_queue | block_calling_process | drop_records.
 -type partitioner() :: random|consistent|consistent_random|murmur2|murmur2_random.
--type headers() :: undefined | proplists:proplist() | maps:map().
+-type headers() :: undefined | proplists:proplist() | map().
 -type callback_module() :: {callback_module, atom()}.
 -type callback_args() :: {callback_args, [any()]}.
 -type dispatch_mode() :: one_by_one | {batch, non_neg_integer()}.


### PR DESCRIPTION
### Problem
Dialyzer check fails for Erlang 17+

The `maps:map()` type was removed in [OTP_17.0-rc1](https://github.com/erlang/otp/releases/tag/OTP_17.0-rc1) See [commit](https://github.com/erlang/otp/commit/94963032a2bb7bd5bfe5ea05d99ca507e67e7ad7) for reference.

### Proposal
Use the common `map()` type instead

